### PR TITLE
chore: update Ruby to 3.4.8 and nokogiri to 1.19.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.4.1'
+          - '3.4.8'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4.1"
+          ruby-version: "3.4.8"
           bundler-cache: true
       - name: Build docs site
         run: bin/build-docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4.1'
+          ruby-version: '3.4.8'
           bundler-cache: true
 
       - name: Run tests

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "base64", "~> 0.2.0"
-gem "nokogiri", "~> 1.18"
+gem "nokogiri", "~> 1.19"
 gem "rake", "~> 13.0"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     facturae (0.1.0)
-      nokogiri (~> 1.11)
+      nokogiri (~> 1.19)
 
 GEM
   remote: https://rubygems.org/
@@ -83,10 +83,10 @@ GEM
     logger (1.6.6)
     mercenary (0.4.0)
     mini_portile2 (2.8.9)
-    nokogiri (1.18.9)
+    nokogiri (1.19.1)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-linux-gnu)
+    nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
     observer (0.1.2)
     ostruct (0.6.1)
@@ -206,7 +206,7 @@ DEPENDENCIES
   debug (~> 1.10)
   facturae!
   jekyll (~> 4.3)
-  nokogiri (~> 1.18)
+  nokogiri (~> 1.19)
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)

--- a/facturae.gemspec
+++ b/facturae.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "nokogiri", "~> 1.11"
+  spec.add_dependency "nokogiri", "~> 1.19"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
## Summary

- Bump Ruby from 3.4.1 to 3.4.8 (latest 3.4.x) in all CI workflows (main, pages, release)
- Upgrade nokogiri from ~> 1.18 to ~> 1.19 (resolves to 1.19.1) in Gemfile, gemspec, and lockfile
- Fixes [Dependabot alert #6](https://github.com/mgmerino/facturae-rb/security/dependabot/6) — [GHSA-wx95-c6cv-8532](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-wx95-c6cv-8532) (medium severity: canonicalization return value not checked, enabling SAML signature bypass)

## Test plan

- [x] `bundle exec rspec` — all 132 tests pass locally
- [x] CI passes on this branch